### PR TITLE
add stream process params

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -111,6 +111,19 @@ class Config {
   }
 
   /**
+   * Parse a set of options for Streaming Process
+   * 
+   * @param {Object} params 
+   * @return an object with streaming process parameters.
+   */
+  parseStreamProcessParams(params) {
+    const prms = {
+      mapMetadata: params.mapMetadata || true
+    };
+    return prms;
+  }
+
+  /**
    * Create apiKey&apiSecret signature using body parameters,
    * or just add apiToken to headers.
    */

--- a/lib/config.js
+++ b/lib/config.js
@@ -112,13 +112,13 @@ class Config {
 
   /**
    * Parse a set of options for Streaming Process
-   * 
-   * @param {Object} params 
+   *
+   * @param {Object} params
    * @return an object with streaming process parameters.
    */
-  parseStreamProcessParams(params) {
+  parseStreamProcessParams(params = {}) {
     const prms = {
-      mapMetadata: params.mapMetadata || true
+      mapMetadata: params.mapMetadata === false ? params.mapMetadata : true
     };
     return prms;
   }

--- a/test/options.js
+++ b/test/options.js
@@ -178,5 +178,25 @@ describe('Config validation', () => {
     });
     config.validate(opc).should.equal(true);
   });
+
+  it('parse valid stream process parameters (default value)', () => {
+    const streamOpts = config.create({
+      url,
+      apiKey,
+      apiSecret,
+    }).parseStreamProcessParams();
+
+    streamOpts.mapMetadata.should.equal(true);
+  });
+
+  it('parse valid stream process parameters (modified)', () => {
+    const streamOpts = config.create({
+      url,
+      apiKey,
+      apiSecret,
+    }).parseStreamProcessParams({ mapMetadata: false });
+
+    streamOpts.mapMetadata.should.equal(false);
+  });
 });
 


### PR DESCRIPTION
Added a method for stream process params.

It will be used by `browser-sdk` for parsing the opt-in configurations on streaming data process. For example, in mapping events to its column using its metadata.