### PR TITLE
Option to select separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Change log.
 
+## Version 2.0.1
+
+* The separator between events (\\r\\n by default) can be changed in the options parameter.
+
 ## Version 1.6.3
 
 * Clean up package contents

--- a/lib/config.js
+++ b/lib/config.js
@@ -59,6 +59,7 @@ class Config {
    *  - queryId: alternatively identifies a particular query in the server.
    *  - destination: optional destination for the data.
    *  - ipAsString: optional return ip as string.
+   *  - separator: optional line separator if it is not \r\n.
    * @param format optionally the format to use, has precedence on
    * options.format.
    * @return an object with parsed url, body and headers.

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,6 +95,7 @@ class Config {
         params: options.destination.params,
       }
     }
+    if (options.separator) opc.separator = options.separator;
     this._generateSignature(opc);
     return opc;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@devoinc/js-helper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devoinc/js-helper",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Devo JavaScript helper library",
   "author": "Devo Dev Team",
   "eslintConfig": {


### PR DESCRIPTION
The API may send streaming data using `\n` as separator instead of `\r\n`. This PR allows to indicate any separator using the options parameter.

@Worvast 